### PR TITLE
Get rid of the regulator member, was just there to simplify code gene…

### DIFF
--- a/tools/Config_Handlers/Basic_Deployment_Data.cpp
+++ b/tools/Config_Handlers/Basic_Deployment_Data.cpp
@@ -10,9 +10,9 @@
  */
 #include "Basic_Deployment_Data.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -21,16 +21,14 @@ namespace DAnCE
   {
     // IdRef
 
-    IdRef::IdRef () :
-    regulator__ ()
+    IdRef::IdRef ()
     {
     }
 
     IdRef::IdRef (IdRef const& s) :
-    ::XSCRT::Type (s),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    idref_ (s.idref_.get () ? new ::XMLSchema::IDREF<ACE_TCHAR> (*s.idref_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
+    , idref_ (s.idref_.get () ? new ::XMLSchema::IDREF<ACE_TCHAR> (*s.idref_) : 0)
     {
       if (href_.get ()) href_->container (this);
       if (idref_.get ()) idref_->container (this);
@@ -163,26 +161,24 @@ namespace DAnCE
 
     // DataType
 
-    DataType::DataType (::DAnCE::Config_Handlers::TCKind const& kind__) :
-    ::XSCRT::Type (),
-    kind_ (new ::DAnCE::Config_Handlers::TCKind (kind__)),
-    regulator__ ()
+    DataType::DataType (::DAnCE::Config_Handlers::TCKind const& kind__)
+    : ::XSCRT::Type ()
+    , kind_ (new ::DAnCE::Config_Handlers::TCKind (kind__))
     {
       kind_->container (this);
     }
 
     DataType::DataType (DataType const& s) :
-    ::XSCRT::Type (s),
-    kind_ (new ::DAnCE::Config_Handlers::TCKind (*s.kind_)),
-    enum__ (s.enum__.get () ? new ::DAnCE::Config_Handlers::EnumType (*s.enum__) : 0),
-    struct__ (s.struct__.get () ? new ::DAnCE::Config_Handlers::StructType (*s.struct__) : 0),
-    value_ (s.value_.get () ? new ::DAnCE::Config_Handlers::ValueType (*s.value_) : 0),
-    sequence_ (s.sequence_.get () ? new ::DAnCE::Config_Handlers::SequenceType (*s.sequence_) : 0),
-    alias_ (s.alias_.get () ? new ::DAnCE::Config_Handlers::AliasType (*s.alias_) : 0),
-    array_ (s.array_.get () ? new ::DAnCE::Config_Handlers::ArrayType (*s.array_) : 0),
-    boundedString_ (s.boundedString_.get () ? new ::DAnCE::Config_Handlers::BoundedStringType (*s.boundedString_) : 0),
-    id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , kind_ (new ::DAnCE::Config_Handlers::TCKind (*s.kind_))
+    , enum__ (s.enum__.get () ? new ::DAnCE::Config_Handlers::EnumType (*s.enum__) : 0)
+    , struct__ (s.struct__.get () ? new ::DAnCE::Config_Handlers::StructType (*s.struct__) : 0)
+    , value_ (s.value_.get () ? new ::DAnCE::Config_Handlers::ValueType (*s.value_) : 0)
+    , sequence_ (s.sequence_.get () ? new ::DAnCE::Config_Handlers::SequenceType (*s.sequence_) : 0)
+    , alias_ (s.alias_.get () ? new ::DAnCE::Config_Handlers::AliasType (*s.alias_) : 0)
+    , array_ (s.array_.get () ? new ::DAnCE::Config_Handlers::ArrayType (*s.array_) : 0)
+    , boundedString_ (s.boundedString_.get () ? new ::DAnCE::Config_Handlers::BoundedStringType (*s.boundedString_) : 0)
+    , id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0)
     {
       kind_->container (this);
       if (enum__.get ()) enum__->container (this);
@@ -491,30 +487,28 @@ namespace DAnCE
 
     // DataValue
 
-    DataValue::DataValue () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    DataValue::DataValue ()
+    : ::XSCRT::Type ()
     {
     }
 
     DataValue::DataValue (DataValue const& s) :
-    ::XSCRT::Type (s),
-    short__ (s.short__),
-    long__ (s.long__),
-    ushort_ (s.ushort_),
-    ulong_ (s.ulong_),
-    float__ (s.float__),
-    double__ (s.double__),
-    boolean_ (s.boolean_),
-    octet_ (s.octet_),
-    enum__ (s.enum__),
-    string_ (s.string_),
-    longlong_ (s.longlong_),
-    ulonglong_ (s.ulonglong_),
-    longdouble_ (s.longdouble_),
-    element_ (s.element_),
-    member_ (s.member_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , short__ (s.short__)
+    , long__ (s.long__)
+    , ushort_ (s.ushort_)
+    , ulong_ (s.ulong_)
+    , float__ (s.float__)
+    , double__ (s.double__)
+    , boolean_ (s.boolean_)
+    , octet_ (s.octet_)
+    , enum__ (s.enum__)
+    , string_ (s.string_)
+    , longlong_ (s.longlong_)
+    , ulonglong_ (s.ulonglong_)
+    , longdouble_ (s.longdouble_)
+    , element_ (s.element_)
+    , member_ (s.member_)
     {
     }
 
@@ -1118,12 +1112,11 @@ namespace DAnCE
 
     AliasType::AliasType (::XMLSchema::string<ACE_TCHAR> const& name__,
                           ::XMLSchema::string<ACE_TCHAR> const& typeId__,
-                          ::DAnCE::Config_Handlers::DataType const& elementType__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__)),
-    elementType_ (new ::DAnCE::Config_Handlers::DataType (elementType__)),
-    regulator__ ()
+                          ::DAnCE::Config_Handlers::DataType const& elementType__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__))
+    , elementType_ (new ::DAnCE::Config_Handlers::DataType (elementType__))
     {
       name_->container (this);
       typeId_->container (this);
@@ -1131,11 +1124,10 @@ namespace DAnCE
     }
 
     AliasType::AliasType (AliasType const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_)),
-    elementType_ (new ::DAnCE::Config_Handlers::DataType (*s.elementType_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_))
+    , elementType_ (new ::DAnCE::Config_Handlers::DataType (*s.elementType_))
     {
       name_->container (this);
       typeId_->container (this);
@@ -1202,23 +1194,21 @@ namespace DAnCE
 
     EnumType::EnumType (::XMLSchema::string<ACE_TCHAR> const& name__,
                         ::XMLSchema::string<ACE_TCHAR> const& typeId__,
-                        member_container_type const& member__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__)),
-    member_ (member__),
-    regulator__ ()
+                        member_container_type const& member__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__))
+    , member_ (member__)
     {
       name_->container (this);
       typeId_->container (this);
     }
 
     EnumType::EnumType (EnumType const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_)),
-    member_ (s.member_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_))
+    , member_ (s.member_)
     {
       name_->container (this);
       typeId_->container (this);
@@ -1306,16 +1296,14 @@ namespace DAnCE
 
     // BoundedStringType
 
-    BoundedStringType::BoundedStringType () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    BoundedStringType::BoundedStringType ()
+    : ::XSCRT::Type ()
     {
     }
 
     BoundedStringType::BoundedStringType (BoundedStringType const& s) :
-    ::XSCRT::Type (s),
-    bound_ (s.bound_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , bound_ (s.bound_)
     {
     }
 
@@ -1372,22 +1360,20 @@ namespace DAnCE
     // StructType
 
     StructType::StructType (::XMLSchema::string<ACE_TCHAR> const& name__,
-                            ::XMLSchema::string<ACE_TCHAR> const& typeId__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__)),
-    regulator__ ()
+                            ::XMLSchema::string<ACE_TCHAR> const& typeId__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__))
     {
       name_->container (this);
       typeId_->container (this);
     }
 
     StructType::StructType (StructType const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_)),
-    member_ (s.member_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_))
+    , member_ (s.member_)
     {
       name_->container (this);
       typeId_->container (this);
@@ -1476,21 +1462,19 @@ namespace DAnCE
     // StructMemberType
 
     StructMemberType::StructMemberType (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                        ::DAnCE::Config_Handlers::DataType const& type__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    type_ (new ::DAnCE::Config_Handlers::DataType (type__)),
-    regulator__ ()
+                                        ::DAnCE::Config_Handlers::DataType const& type__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , type_ (new ::DAnCE::Config_Handlers::DataType (type__))
     {
       name_->container (this);
       type_->container (this);
     }
 
     StructMemberType::StructMemberType (StructMemberType const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_))
     {
       name_->container (this);
       type_->container (this);
@@ -1542,13 +1526,12 @@ namespace DAnCE
     ValueType::ValueType (::XMLSchema::string<ACE_TCHAR> const& name__,
                           ::XMLSchema::string<ACE_TCHAR> const& typeId__,
                           ::XMLSchema::string<ACE_TCHAR> const& modifier__,
-                          ::DAnCE::Config_Handlers::DataType const& baseType__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__)),
-    modifier_ (new ::XMLSchema::string<ACE_TCHAR> (modifier__)),
-    baseType_ (new ::DAnCE::Config_Handlers::DataType (baseType__)),
-    regulator__ ()
+                          ::DAnCE::Config_Handlers::DataType const& baseType__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (typeId__))
+    , modifier_ (new ::XMLSchema::string<ACE_TCHAR> (modifier__))
+    , baseType_ (new ::DAnCE::Config_Handlers::DataType (baseType__))
     {
       name_->container (this);
       typeId_->container (this);
@@ -1557,13 +1540,12 @@ namespace DAnCE
     }
 
     ValueType::ValueType (ValueType const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_)),
-    modifier_ (new ::XMLSchema::string<ACE_TCHAR> (*s.modifier_)),
-    baseType_ (new ::DAnCE::Config_Handlers::DataType (*s.baseType_)),
-    member_ (s.member_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , typeId_ (new ::XMLSchema::string<ACE_TCHAR> (*s.typeId_))
+    , modifier_ (new ::XMLSchema::string<ACE_TCHAR> (*s.modifier_))
+    , baseType_ (new ::DAnCE::Config_Handlers::DataType (*s.baseType_))
+    , member_ (s.member_)
     {
       name_->container (this);
       typeId_->container (this);
@@ -1685,12 +1667,11 @@ namespace DAnCE
 
     ValueMemberType::ValueMemberType (::XMLSchema::string<ACE_TCHAR> const& name__,
                                       ::XMLSchema::string<ACE_TCHAR> const& visibility__,
-                                      ::DAnCE::Config_Handlers::DataType const& type__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    visibility_ (new ::XMLSchema::string<ACE_TCHAR> (visibility__)),
-    type_ (new ::DAnCE::Config_Handlers::DataType (type__)),
-    regulator__ ()
+                                      ::DAnCE::Config_Handlers::DataType const& type__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , visibility_ (new ::XMLSchema::string<ACE_TCHAR> (visibility__))
+    , type_ (new ::DAnCE::Config_Handlers::DataType (type__))
     {
       name_->container (this);
       visibility_->container (this);
@@ -1698,11 +1679,10 @@ namespace DAnCE
     }
 
     ValueMemberType::ValueMemberType (ValueMemberType const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    visibility_ (new ::XMLSchema::string<ACE_TCHAR> (*s.visibility_)),
-    type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , visibility_ (new ::XMLSchema::string<ACE_TCHAR> (*s.visibility_))
+    , type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_))
     {
       name_->container (this);
       visibility_->container (this);
@@ -1768,21 +1748,19 @@ namespace DAnCE
     // NamedValue
 
     NamedValue::NamedValue (::XMLSchema::string<ACE_TCHAR> const& name__,
-                            ::DAnCE::Config_Handlers::DataValue const& value__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    value_ (new ::DAnCE::Config_Handlers::DataValue (value__)),
-    regulator__ ()
+                            ::DAnCE::Config_Handlers::DataValue const& value__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , value_ (new ::DAnCE::Config_Handlers::DataValue (value__))
     {
       name_->container (this);
       value_->container (this);
     }
 
     NamedValue::NamedValue (NamedValue const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    value_ (new ::DAnCE::Config_Handlers::DataValue (*s.value_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , value_ (new ::DAnCE::Config_Handlers::DataValue (*s.value_))
     {
       name_->container (this);
       value_->container (this);
@@ -1832,21 +1810,19 @@ namespace DAnCE
     // ArrayType
 
     ArrayType::ArrayType (::XMLSchema::unsignedInt const& length__,
-                          ::DAnCE::Config_Handlers::DataType const& elementType__) :
-    ::XSCRT::Type (),
-    length_ (new ::XMLSchema::unsignedInt (length__)),
-    elementType_ (new ::DAnCE::Config_Handlers::DataType (elementType__)),
-    regulator__ ()
+                          ::DAnCE::Config_Handlers::DataType const& elementType__)
+    : ::XSCRT::Type ()
+    , length_ (new ::XMLSchema::unsignedInt (length__))
+    , elementType_ (new ::DAnCE::Config_Handlers::DataType (elementType__))
     {
       length_->container (this);
       elementType_->container (this);
     }
 
     ArrayType::ArrayType (ArrayType const& s) :
-    ::XSCRT::Type (s),
-    length_ (new ::XMLSchema::unsignedInt (*s.length_)),
-    elementType_ (new ::DAnCE::Config_Handlers::DataType (*s.elementType_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , length_ (new ::XMLSchema::unsignedInt (*s.length_))
+    , elementType_ (new ::DAnCE::Config_Handlers::DataType (*s.elementType_))
     {
       length_->container (this);
       elementType_->container (this);
@@ -1895,19 +1871,17 @@ namespace DAnCE
 
     // SequenceType
 
-    SequenceType::SequenceType (::DAnCE::Config_Handlers::DataType const& elementType__) :
-    ::XSCRT::Type (),
-    elementType_ (new ::DAnCE::Config_Handlers::DataType (elementType__)),
-    regulator__ ()
+    SequenceType::SequenceType (::DAnCE::Config_Handlers::DataType const& elementType__)
+    : ::XSCRT::Type ()
+    , elementType_ (new ::DAnCE::Config_Handlers::DataType (elementType__))
     {
       elementType_->container (this);
     }
 
     SequenceType::SequenceType (SequenceType const& s) :
-    ::XSCRT::Type (s),
-    bound_ (s.bound_.get () ? new ::XMLSchema::unsignedInt (*s.bound_) : 0),
-    elementType_ (new ::DAnCE::Config_Handlers::DataType (*s.elementType_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , bound_ (s.bound_.get () ? new ::XMLSchema::unsignedInt (*s.bound_) : 0)
+    , elementType_ (new ::DAnCE::Config_Handlers::DataType (*s.elementType_))
     {
       if (bound_.get ()) bound_->container (this);
       elementType_->container (this);
@@ -1975,21 +1949,19 @@ namespace DAnCE
     // Any
 
     Any::Any (::DAnCE::Config_Handlers::DataType const& type__,
-              ::DAnCE::Config_Handlers::DataValue const& value__) :
-    ::XSCRT::Type (),
-    type_ (new ::DAnCE::Config_Handlers::DataType (type__)),
-    value_ (new ::DAnCE::Config_Handlers::DataValue (value__)),
-    regulator__ ()
+              ::DAnCE::Config_Handlers::DataValue const& value__)
+    : ::XSCRT::Type ()
+    , type_ (new ::DAnCE::Config_Handlers::DataType (type__))
+    , value_ (new ::DAnCE::Config_Handlers::DataValue (value__))
     {
       type_->container (this);
       value_->container (this);
     }
 
     Any::Any (Any const& s) :
-    ::XSCRT::Type (s),
-    type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_)),
-    value_ (new ::DAnCE::Config_Handlers::DataValue (*s.value_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_))
+    , value_ (new ::DAnCE::Config_Handlers::DataValue (*s.value_))
     {
       type_->container (this);
       value_->container (this);
@@ -2039,21 +2011,19 @@ namespace DAnCE
     // Property
 
     Property::Property (::XMLSchema::string<ACE_TCHAR> const& name__,
-                        ::DAnCE::Config_Handlers::Any const& value__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    value_ (new ::DAnCE::Config_Handlers::Any (value__)),
-    regulator__ ()
+                        ::DAnCE::Config_Handlers::Any const& value__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , value_ (new ::DAnCE::Config_Handlers::Any (value__))
     {
       name_->container (this);
       value_->container (this);
     }
 
     Property::Property (Property const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    value_ (new ::DAnCE::Config_Handlers::Any (*s.value_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , value_ (new ::DAnCE::Config_Handlers::Any (*s.value_))
     {
       name_->container (this);
       value_->container (this);
@@ -2131,13 +2101,12 @@ namespace DAnCE
     SatisfierProperty::SatisfierProperty (::XMLSchema::string<ACE_TCHAR> const& name__,
                                           ::DAnCE::Config_Handlers::SatisfierPropertyKind const& kind__,
                                           ::XMLSchema::boolean const& dynamic__,
-                                          ::DAnCE::Config_Handlers::Any const& value__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    kind_ (new ::DAnCE::Config_Handlers::SatisfierPropertyKind (kind__)),
-    dynamic_ (new ::XMLSchema::boolean (dynamic__)),
-    value_ (new ::DAnCE::Config_Handlers::Any (value__)),
-    regulator__ ()
+                                          ::DAnCE::Config_Handlers::Any const& value__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , kind_ (new ::DAnCE::Config_Handlers::SatisfierPropertyKind (kind__))
+    , dynamic_ (new ::XMLSchema::boolean (dynamic__))
+    , value_ (new ::DAnCE::Config_Handlers::Any (value__))
     {
       name_->container (this);
       kind_->container (this);
@@ -2146,12 +2115,11 @@ namespace DAnCE
     }
 
     SatisfierProperty::SatisfierProperty (SatisfierProperty const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    kind_ (new ::DAnCE::Config_Handlers::SatisfierPropertyKind (*s.kind_)),
-    dynamic_ (new ::XMLSchema::boolean (*s.dynamic_)),
-    value_ (new ::DAnCE::Config_Handlers::Any (*s.value_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , kind_ (new ::DAnCE::Config_Handlers::SatisfierPropertyKind (*s.kind_))
+    , dynamic_ (new ::XMLSchema::boolean (*s.dynamic_))
+    , value_ (new ::DAnCE::Config_Handlers::Any (*s.value_))
     {
       name_->container (this);
       kind_->container (this);
@@ -2233,21 +2201,19 @@ namespace DAnCE
     // Resource
 
     Resource::Resource (::XMLSchema::string<ACE_TCHAR> const& name__,
-                        resourceType_container_type const& resourceType__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    resourceType_ (resourceType__),
-    regulator__ ()
+                        resourceType_container_type const& resourceType__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , resourceType_ (resourceType__)
     {
       name_->container (this);
     }
 
     Resource::Resource (Resource const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    resourceType_ (s.resourceType_),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , resourceType_ (s.resourceType_)
+    , property_ (s.property_)
     {
       name_->container (this);
     }
@@ -2359,22 +2325,20 @@ namespace DAnCE
     // Requirement
 
     Requirement::Requirement (::XMLSchema::string<ACE_TCHAR> const& name__,
-                              ::XMLSchema::string<ACE_TCHAR> const& resourceType__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (resourceType__)),
-    regulator__ ()
+                              ::XMLSchema::string<ACE_TCHAR> const& resourceType__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (resourceType__))
     {
       name_->container (this);
       resourceType_->container (this);
     }
 
     Requirement::Requirement (Requirement const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceType_)),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceType_))
+    , property_ (s.property_)
     {
       name_->container (this);
       resourceType_->container (this);
@@ -2463,22 +2427,20 @@ namespace DAnCE
     // ResourceDeploymentDescription
 
     ResourceDeploymentDescription::ResourceDeploymentDescription (::XMLSchema::string<ACE_TCHAR> const& requirementName__,
-                                                                  ::XMLSchema::string<ACE_TCHAR> const& resourceName__) :
-    ::XSCRT::Type (),
-    requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (requirementName__)),
-    resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (resourceName__)),
-    regulator__ ()
+                                                                  ::XMLSchema::string<ACE_TCHAR> const& resourceName__)
+    : ::XSCRT::Type ()
+    , requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (requirementName__))
+    , resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (resourceName__))
     {
       requirementName_->container (this);
       resourceName_->container (this);
     }
 
     ResourceDeploymentDescription::ResourceDeploymentDescription (ResourceDeploymentDescription const& s) :
-    ::XSCRT::Type (s),
-    requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requirementName_)),
-    resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceName_)),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requirementName_))
+    , resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceName_))
+    , property_ (s.property_)
     {
       requirementName_->container (this);
       resourceName_->container (this);
@@ -2567,27 +2529,25 @@ namespace DAnCE
     // ArtifactDeploymentDescription
 
     ArtifactDeploymentDescription::ArtifactDeploymentDescription (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                                                  ::XMLSchema::string<ACE_TCHAR> const& node__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    node_ (new ::XMLSchema::string<ACE_TCHAR> (node__)),
-    regulator__ ()
+                                                                  ::XMLSchema::string<ACE_TCHAR> const& node__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , node_ (new ::XMLSchema::string<ACE_TCHAR> (node__))
     {
       name_->container (this);
       node_->container (this);
     }
 
     ArtifactDeploymentDescription::ArtifactDeploymentDescription (ArtifactDeploymentDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    source_ (s.source_),
-    node_ (new ::XMLSchema::string<ACE_TCHAR> (*s.node_)),
-    location_ (s.location_),
-    execParameter_ (s.execParameter_),
-    deployRequirement_ (s.deployRequirement_),
-    deployedResource_ (s.deployedResource_),
-    id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , source_ (s.source_)
+    , node_ (new ::XMLSchema::string<ACE_TCHAR> (*s.node_))
+    , location_ (s.location_)
+    , execParameter_ (s.execParameter_)
+    , deployRequirement_ (s.deployRequirement_)
+    , deployedResource_ (s.deployedResource_)
+    , id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0)
     {
       name_->container (this);
       node_->container (this);
@@ -2869,23 +2829,21 @@ namespace DAnCE
 
     // MonolithicDeploymentDescription
 
-    MonolithicDeploymentDescription::MonolithicDeploymentDescription (::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+    MonolithicDeploymentDescription::MonolithicDeploymentDescription (::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       name_->container (this);
     }
 
     MonolithicDeploymentDescription::MonolithicDeploymentDescription (MonolithicDeploymentDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    source_ (s.source_),
-    artifact_ (s.artifact_),
-    execParameter_ (s.execParameter_),
-    deployRequirement_ (s.deployRequirement_),
-    id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , source_ (s.source_)
+    , artifact_ (s.artifact_)
+    , execParameter_ (s.execParameter_)
+    , deployRequirement_ (s.deployRequirement_)
+    , id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0)
     {
       name_->container (this);
       if (id_.get ()) id_->container (this);
@@ -3140,12 +3098,11 @@ namespace DAnCE
 
     InstanceResourceDeploymentDescription::InstanceResourceDeploymentDescription (::DAnCE::Config_Handlers::ResourceUsageKind const& resourceUsage__,
                                                                                   ::XMLSchema::string<ACE_TCHAR> const& requirementName__,
-                                                                                  ::XMLSchema::string<ACE_TCHAR> const& resourceName__) :
-    ::XSCRT::Type (),
-    resourceUsage_ (new ::DAnCE::Config_Handlers::ResourceUsageKind (resourceUsage__)),
-    requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (requirementName__)),
-    resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (resourceName__)),
-    regulator__ ()
+                                                                                  ::XMLSchema::string<ACE_TCHAR> const& resourceName__)
+    : ::XSCRT::Type ()
+    , resourceUsage_ (new ::DAnCE::Config_Handlers::ResourceUsageKind (resourceUsage__))
+    , requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (requirementName__))
+    , resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (resourceName__))
     {
       resourceUsage_->container (this);
       requirementName_->container (this);
@@ -3153,12 +3110,11 @@ namespace DAnCE
     }
 
     InstanceResourceDeploymentDescription::InstanceResourceDeploymentDescription (InstanceResourceDeploymentDescription const& s) :
-    ::XSCRT::Type (s),
-    resourceUsage_ (new ::DAnCE::Config_Handlers::ResourceUsageKind (*s.resourceUsage_)),
-    requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requirementName_)),
-    resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceName_)),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , resourceUsage_ (new ::DAnCE::Config_Handlers::ResourceUsageKind (*s.resourceUsage_))
+    , requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requirementName_))
+    , resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceName_))
+    , property_ (s.property_)
     {
       resourceUsage_->container (this);
       requirementName_->container (this);
@@ -3265,13 +3221,12 @@ namespace DAnCE
     InstanceDeploymentDescription::InstanceDeploymentDescription (::XMLSchema::string<ACE_TCHAR> const& name__,
                                                                   ::XMLSchema::string<ACE_TCHAR> const& node__,
                                                                   ::XMLSchema::string<ACE_TCHAR> const& source__,
-                                                                  ::DAnCE::Config_Handlers::IdRef const& implementation__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    node_ (new ::XMLSchema::string<ACE_TCHAR> (node__)),
-    source_ (new ::XMLSchema::string<ACE_TCHAR> (source__)),
-    implementation_ (new ::DAnCE::Config_Handlers::IdRef (implementation__)),
-    regulator__ ()
+                                                                  ::DAnCE::Config_Handlers::IdRef const& implementation__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , node_ (new ::XMLSchema::string<ACE_TCHAR> (node__))
+    , source_ (new ::XMLSchema::string<ACE_TCHAR> (source__))
+    , implementation_ (new ::DAnCE::Config_Handlers::IdRef (implementation__))
     {
       name_->container (this);
       node_->container (this);
@@ -3280,16 +3235,15 @@ namespace DAnCE
     }
 
     InstanceDeploymentDescription::InstanceDeploymentDescription (InstanceDeploymentDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    node_ (new ::XMLSchema::string<ACE_TCHAR> (*s.node_)),
-    source_ (new ::XMLSchema::string<ACE_TCHAR> (*s.source_)),
-    implementation_ (new ::DAnCE::Config_Handlers::IdRef (*s.implementation_)),
-    configProperty_ (s.configProperty_),
-    deployedResource_ (s.deployedResource_),
-    deployedSharedResource_ (s.deployedSharedResource_.get () ? new ::DAnCE::Config_Handlers::InstanceResourceDeploymentDescription (*s.deployedSharedResource_) : 0),
-    id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , node_ (new ::XMLSchema::string<ACE_TCHAR> (*s.node_))
+    , source_ (new ::XMLSchema::string<ACE_TCHAR> (*s.source_))
+    , implementation_ (new ::DAnCE::Config_Handlers::IdRef (*s.implementation_))
+    , configProperty_ (s.configProperty_)
+    , deployedResource_ (s.deployedResource_)
+    , deployedSharedResource_ (s.deployedSharedResource_.get () ? new ::DAnCE::Config_Handlers::InstanceResourceDeploymentDescription (*s.deployedSharedResource_) : 0)
+    , id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0)
     {
       name_->container (this);
       node_->container (this);
@@ -3551,15 +3505,14 @@ namespace DAnCE
                                                         ::XMLSchema::boolean const& exclusiveProvider__,
                                                         ::XMLSchema::boolean const& exclusiveUser__,
                                                         ::XMLSchema::boolean const& optional__,
-                                                        ::DAnCE::Config_Handlers::CCMComponentPortKind const& kind__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    provider_ (new ::XMLSchema::boolean (provider__)),
-    exclusiveProvider_ (new ::XMLSchema::boolean (exclusiveProvider__)),
-    exclusiveUser_ (new ::XMLSchema::boolean (exclusiveUser__)),
-    optional_ (new ::XMLSchema::boolean (optional__)),
-    kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (kind__)),
-    regulator__ ()
+                                                        ::DAnCE::Config_Handlers::CCMComponentPortKind const& kind__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , provider_ (new ::XMLSchema::boolean (provider__))
+    , exclusiveProvider_ (new ::XMLSchema::boolean (exclusiveProvider__))
+    , exclusiveUser_ (new ::XMLSchema::boolean (exclusiveUser__))
+    , optional_ (new ::XMLSchema::boolean (optional__))
+    , kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (kind__))
     {
       name_->container (this);
       provider_->container (this);
@@ -3570,17 +3523,16 @@ namespace DAnCE
     }
 
     ComponentPortDescription::ComponentPortDescription (ComponentPortDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    specificType_ (s.specificType_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.specificType_) : 0),
-    supportedType_ (s.supportedType_),
-    provider_ (new ::XMLSchema::boolean (*s.provider_)),
-    exclusiveProvider_ (new ::XMLSchema::boolean (*s.exclusiveProvider_)),
-    exclusiveUser_ (new ::XMLSchema::boolean (*s.exclusiveUser_)),
-    optional_ (new ::XMLSchema::boolean (*s.optional_)),
-    kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (*s.kind_)),
-    templateParam_ (s.templateParam_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , specificType_ (s.specificType_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.specificType_) : 0)
+    , supportedType_ (s.supportedType_)
+    , provider_ (new ::XMLSchema::boolean (*s.provider_))
+    , exclusiveProvider_ (new ::XMLSchema::boolean (*s.exclusiveProvider_))
+    , exclusiveUser_ (new ::XMLSchema::boolean (*s.exclusiveUser_))
+    , optional_ (new ::XMLSchema::boolean (*s.optional_))
+    , kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (*s.kind_))
+    , templateParam_ (s.templateParam_)
     {
       name_->container (this);
       if (specificType_.get ()) specificType_->container (this);
@@ -3806,21 +3758,19 @@ namespace DAnCE
     // ComponentPropertyDescription
 
     ComponentPropertyDescription::ComponentPropertyDescription (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                                                ::DAnCE::Config_Handlers::DataType const& type__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    type_ (new ::DAnCE::Config_Handlers::DataType (type__)),
-    regulator__ ()
+                                                                ::DAnCE::Config_Handlers::DataType const& type__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , type_ (new ::DAnCE::Config_Handlers::DataType (type__))
     {
       name_->container (this);
       type_->container (this);
     }
 
     ComponentPropertyDescription::ComponentPropertyDescription (ComponentPropertyDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , type_ (new ::DAnCE::Config_Handlers::DataType (*s.type_))
     {
       name_->container (this);
       type_->container (this);
@@ -3869,18 +3819,16 @@ namespace DAnCE
 
     // ComponentExternalPortEndpoint
 
-    ComponentExternalPortEndpoint::ComponentExternalPortEndpoint (::XMLSchema::string<ACE_TCHAR> const& portName__) :
-    ::XSCRT::Type (),
-    portName_ (new ::XMLSchema::string<ACE_TCHAR> (portName__)),
-    regulator__ ()
+    ComponentExternalPortEndpoint::ComponentExternalPortEndpoint (::XMLSchema::string<ACE_TCHAR> const& portName__)
+    : ::XSCRT::Type ()
+    , portName_ (new ::XMLSchema::string<ACE_TCHAR> (portName__))
     {
       portName_->container (this);
     }
 
     ComponentExternalPortEndpoint::ComponentExternalPortEndpoint (ComponentExternalPortEndpoint const& s) :
-    ::XSCRT::Type (s),
-    portName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.portName_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , portName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.portName_))
     {
       portName_->container (this);
     }
@@ -3915,12 +3863,11 @@ namespace DAnCE
 
     PlanSubcomponentPortEndpoint::PlanSubcomponentPortEndpoint (::XMLSchema::string<ACE_TCHAR> const& portName__,
                                                                 ::DAnCE::Config_Handlers::CCMComponentPortKind const& kind__,
-                                                                ::DAnCE::Config_Handlers::IdRef const& instance__) :
-    ::XSCRT::Type (),
-    portName_ (new ::XMLSchema::string<ACE_TCHAR> (portName__)),
-    kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (kind__)),
-    instance_ (new ::DAnCE::Config_Handlers::IdRef (instance__)),
-    regulator__ ()
+                                                                ::DAnCE::Config_Handlers::IdRef const& instance__)
+    : ::XSCRT::Type ()
+    , portName_ (new ::XMLSchema::string<ACE_TCHAR> (portName__))
+    , kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (kind__))
+    , instance_ (new ::DAnCE::Config_Handlers::IdRef (instance__))
     {
       portName_->container (this);
       kind_->container (this);
@@ -3928,12 +3875,11 @@ namespace DAnCE
     }
 
     PlanSubcomponentPortEndpoint::PlanSubcomponentPortEndpoint (PlanSubcomponentPortEndpoint const& s) :
-    ::XSCRT::Type (s),
-    portName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.portName_)),
-    provider_ (s.provider_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.provider_) : 0),
-    kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (*s.kind_)),
-    instance_ (new ::DAnCE::Config_Handlers::IdRef (*s.instance_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , portName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.portName_))
+    , provider_ (s.provider_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.provider_) : 0)
+    , kind_ (new ::DAnCE::Config_Handlers::CCMComponentPortKind (*s.kind_))
+    , instance_ (new ::DAnCE::Config_Handlers::IdRef (*s.instance_))
     {
       portName_->container (this);
       if (provider_.get ()) provider_->container (this);
@@ -4033,23 +3979,21 @@ namespace DAnCE
     // ExternalReferenceEndpoint
 
     ExternalReferenceEndpoint::ExternalReferenceEndpoint (::XMLSchema::string<ACE_TCHAR> const& location__,
-                                                          ::XMLSchema::boolean const& provider__) :
-    ::XSCRT::Type (),
-    location_ (new ::XMLSchema::string<ACE_TCHAR> (location__)),
-    provider_ (new ::XMLSchema::boolean (provider__)),
-    regulator__ ()
+                                                          ::XMLSchema::boolean const& provider__)
+    : ::XSCRT::Type ()
+    , location_ (new ::XMLSchema::string<ACE_TCHAR> (location__))
+    , provider_ (new ::XMLSchema::boolean (provider__))
     {
       location_->container (this);
       provider_->container (this);
     }
 
     ExternalReferenceEndpoint::ExternalReferenceEndpoint (ExternalReferenceEndpoint const& s) :
-    ::XSCRT::Type (s),
-    location_ (new ::XMLSchema::string<ACE_TCHAR> (*s.location_)),
-    provider_ (new ::XMLSchema::boolean (*s.provider_)),
-    portName_ (s.portName_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.portName_) : 0),
-    supportedType_ (s.supportedType_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , location_ (new ::XMLSchema::string<ACE_TCHAR> (*s.location_))
+    , provider_ (new ::XMLSchema::boolean (*s.provider_))
+    , portName_ (s.portName_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.portName_) : 0)
+    , supportedType_ (s.supportedType_)
     {
       location_->container (this);
       provider_->container (this);
@@ -4173,12 +4117,11 @@ namespace DAnCE
 
     ConnectionResourceDeploymentDescription::ConnectionResourceDeploymentDescription (::XMLSchema::string<ACE_TCHAR> const& targetName__,
                                                                                       ::XMLSchema::string<ACE_TCHAR> const& requirementName__,
-                                                                                      ::XMLSchema::string<ACE_TCHAR> const& resourceName__) :
-    ::XSCRT::Type (),
-    targetName_ (new ::XMLSchema::string<ACE_TCHAR> (targetName__)),
-    requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (requirementName__)),
-    resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (resourceName__)),
-    regulator__ ()
+                                                                                      ::XMLSchema::string<ACE_TCHAR> const& resourceName__)
+    : ::XSCRT::Type ()
+    , targetName_ (new ::XMLSchema::string<ACE_TCHAR> (targetName__))
+    , requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (requirementName__))
+    , resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (resourceName__))
     {
       targetName_->container (this);
       requirementName_->container (this);
@@ -4186,12 +4129,11 @@ namespace DAnCE
     }
 
     ConnectionResourceDeploymentDescription::ConnectionResourceDeploymentDescription (ConnectionResourceDeploymentDescription const& s) :
-    ::XSCRT::Type (s),
-    targetName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.targetName_)),
-    requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requirementName_)),
-    resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceName_)),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , targetName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.targetName_))
+    , requirementName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requirementName_))
+    , resourceName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceName_))
+    , property_ (s.property_)
     {
       targetName_->container (this);
       requirementName_->container (this);
@@ -4295,24 +4237,22 @@ namespace DAnCE
 
     // PlanConnectionDescription
 
-    PlanConnectionDescription::PlanConnectionDescription (::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+    PlanConnectionDescription::PlanConnectionDescription (::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       name_->container (this);
     }
 
     PlanConnectionDescription::PlanConnectionDescription (PlanConnectionDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    source_ (s.source_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.source_) : 0),
-    deployRequirement_ (s.deployRequirement_),
-    externalEndpoint_ (s.externalEndpoint_),
-    internalEndpoint_ (s.internalEndpoint_),
-    externalReference_ (s.externalReference_),
-    deployedResource_ (s.deployedResource_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , source_ (s.source_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.source_) : 0)
+    , deployRequirement_ (s.deployRequirement_)
+    , externalEndpoint_ (s.externalEndpoint_)
+    , internalEndpoint_ (s.internalEndpoint_)
+    , externalReference_ (s.externalReference_)
+    , deployedResource_ (s.deployedResource_)
     {
       name_->container (this);
       if (source_.get ()) source_->container (this);
@@ -4574,18 +4514,16 @@ namespace DAnCE
 
     // ImplementationDependency
 
-    ImplementationDependency::ImplementationDependency (::XMLSchema::string<ACE_TCHAR> const& requiredType__) :
-    ::XSCRT::Type (),
-    requiredType_ (new ::XMLSchema::string<ACE_TCHAR> (requiredType__)),
-    regulator__ ()
+    ImplementationDependency::ImplementationDependency (::XMLSchema::string<ACE_TCHAR> const& requiredType__)
+    : ::XSCRT::Type ()
+    , requiredType_ (new ::XMLSchema::string<ACE_TCHAR> (requiredType__))
     {
       requiredType_->container (this);
     }
 
     ImplementationDependency::ImplementationDependency (ImplementationDependency const& s) :
-    ::XSCRT::Type (s),
-    requiredType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requiredType_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , requiredType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.requiredType_))
     {
       requiredType_->container (this);
     }
@@ -4618,20 +4556,18 @@ namespace DAnCE
 
     // Capability
 
-    Capability::Capability (::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+    Capability::Capability (::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       name_->container (this);
     }
 
     Capability::Capability (Capability const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    resourceType_ (s.resourceType_),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , resourceType_ (s.resourceType_)
+    , property_ (s.property_)
     {
       name_->container (this);
     }
@@ -4743,25 +4679,23 @@ namespace DAnCE
     // ImplementationRequirement
 
     ImplementationRequirement::ImplementationRequirement (::XMLSchema::string<ACE_TCHAR> const& resourceType__,
-                                                          ::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (resourceType__)),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+                                                          ::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (resourceType__))
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       resourceType_->container (this);
       name_->container (this);
     }
 
     ImplementationRequirement::ImplementationRequirement (ImplementationRequirement const& s) :
-    ::XSCRT::Type (s),
-    resourceUsage_ (s.resourceUsage_.get () ? new ::DAnCE::Config_Handlers::ResourceUsageKind (*s.resourceUsage_) : 0),
-    resourcePort_ (s.resourcePort_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.resourcePort_) : 0),
-    componentPort_ (s.componentPort_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.componentPort_) : 0),
-    resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceType_)),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    property_ (s.property_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , resourceUsage_ (s.resourceUsage_.get () ? new ::DAnCE::Config_Handlers::ResourceUsageKind (*s.resourceUsage_) : 0)
+    , resourcePort_ (s.resourcePort_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.resourcePort_) : 0)
+    , componentPort_ (s.componentPort_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.componentPort_) : 0)
+    , resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceType_))
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , property_ (s.property_)
     {
       if (resourceUsage_.get ()) resourceUsage_->container (this);
       if (resourcePort_.get ()) resourcePort_->container (this);
@@ -4952,21 +4886,19 @@ namespace DAnCE
     // SubcomponentPortEndpoint
 
     SubcomponentPortEndpoint::SubcomponentPortEndpoint (::XMLSchema::string<ACE_TCHAR> const& portName__,
-                                                        ::DAnCE::Config_Handlers::IdRef const& instance__) :
-    ::XSCRT::Type (),
-    portName_ (new ::XMLSchema::string<ACE_TCHAR> (portName__)),
-    instance_ (new ::DAnCE::Config_Handlers::IdRef (instance__)),
-    regulator__ ()
+                                                        ::DAnCE::Config_Handlers::IdRef const& instance__)
+    : ::XSCRT::Type ()
+    , portName_ (new ::XMLSchema::string<ACE_TCHAR> (portName__))
+    , instance_ (new ::DAnCE::Config_Handlers::IdRef (instance__))
     {
       portName_->container (this);
       instance_->container (this);
     }
 
     SubcomponentPortEndpoint::SubcomponentPortEndpoint (SubcomponentPortEndpoint const& s) :
-    ::XSCRT::Type (s),
-    portName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.portName_)),
-    instance_ (new ::DAnCE::Config_Handlers::IdRef (*s.instance_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , portName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.portName_))
+    , instance_ (new ::DAnCE::Config_Handlers::IdRef (*s.instance_))
     {
       portName_->container (this);
       instance_->container (this);
@@ -5015,22 +4947,20 @@ namespace DAnCE
 
     // AssemblyConnectionDescription
 
-    AssemblyConnectionDescription::AssemblyConnectionDescription (::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+    AssemblyConnectionDescription::AssemblyConnectionDescription (::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       name_->container (this);
     }
 
     AssemblyConnectionDescription::AssemblyConnectionDescription (AssemblyConnectionDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    deployRequirement_ (s.deployRequirement_),
-    internalEndpoint_ (s.internalEndpoint_),
-    externalEndpoint_ (s.externalEndpoint_),
-    externalReference_ (s.externalReference_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , deployRequirement_ (s.deployRequirement_)
+    , internalEndpoint_ (s.internalEndpoint_)
+    , externalEndpoint_ (s.externalEndpoint_)
+    , externalReference_ (s.externalReference_)
     {
       name_->container (this);
     }
@@ -5246,20 +5176,18 @@ namespace DAnCE
     // PlanLocality
 
     PlanLocality::PlanLocality (::DAnCE::Config_Handlers::PlanLocalityKind const& constraint__,
-                                constrainedInstance_container_type const& constrainedInstance__) :
-    ::XSCRT::Type (),
-    constraint_ (new ::DAnCE::Config_Handlers::PlanLocalityKind (constraint__)),
-    constrainedInstance_ (constrainedInstance__),
-    regulator__ ()
+                                constrainedInstance_container_type const& constrainedInstance__)
+    : ::XSCRT::Type ()
+    , constraint_ (new ::DAnCE::Config_Handlers::PlanLocalityKind (constraint__))
+    , constrainedInstance_ (constrainedInstance__)
     {
       constraint_->container (this);
     }
 
     PlanLocality::PlanLocality (PlanLocality const& s) :
-    ::XSCRT::Type (s),
-    constraint_ (new ::DAnCE::Config_Handlers::PlanLocalityKind (*s.constraint_)),
-    constrainedInstance_ (s.constrainedInstance_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , constraint_ (new ::DAnCE::Config_Handlers::PlanLocalityKind (*s.constraint_))
+    , constrainedInstance_ (s.constrainedInstance_)
     {
       constraint_->container (this);
     }
@@ -5338,7 +5266,7 @@ namespace DAnCE
 
     IdRef::
     IdRef (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5359,8 +5287,7 @@ namespace DAnCE
           idref (t);
           std::basic_string<ACE_TCHAR> temp ((*idref_).id().c_str());
 
-          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-          add_idref(temp, dynamic_cast<XSCRT::Type*> (this));
+          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_idref(temp, this);
         }
 
         else
@@ -5509,7 +5436,7 @@ namespace DAnCE
 
     DataType::
     DataType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5581,8 +5508,7 @@ namespace DAnCE
           ::XMLSchema::ID<ACE_TCHAR> t (a);
           id (t);
           std::basic_string<ACE_TCHAR> temp ((*id_).c_str());
-          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-          add_id(temp, dynamic_cast<XSCRT::Type*> (this));
+          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_id(temp, this);
         }
 
         else
@@ -5595,7 +5521,7 @@ namespace DAnCE
 
     DataValue::
     DataValue (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5705,7 +5631,7 @@ namespace DAnCE
 
     AliasType::
     AliasType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5743,7 +5669,7 @@ namespace DAnCE
 
     EnumType::
     EnumType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5781,7 +5707,7 @@ namespace DAnCE
 
     BoundedStringType::
     BoundedStringType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5807,7 +5733,7 @@ namespace DAnCE
 
     StructType::
     StructType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5845,7 +5771,7 @@ namespace DAnCE
 
     StructMemberType::
     StructMemberType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5877,7 +5803,7 @@ namespace DAnCE
 
     ValueType::
     ValueType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5927,7 +5853,7 @@ namespace DAnCE
 
     ValueMemberType::
     ValueMemberType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5965,7 +5891,7 @@ namespace DAnCE
 
     NamedValue::
     NamedValue (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -5997,7 +5923,7 @@ namespace DAnCE
 
     ArrayType::
     ArrayType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6029,7 +5955,7 @@ namespace DAnCE
 
     SequenceType::
     SequenceType (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6061,7 +5987,7 @@ namespace DAnCE
 
     Any::
     Any (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6093,7 +6019,7 @@ namespace DAnCE
 
     Property::
     Property (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6168,7 +6094,7 @@ namespace DAnCE
 
     SatisfierProperty::
     SatisfierProperty (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6212,7 +6138,7 @@ namespace DAnCE
 
     Resource::
     Resource (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6250,7 +6176,7 @@ namespace DAnCE
 
     Requirement::
     Requirement (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6288,7 +6214,7 @@ namespace DAnCE
 
     ResourceDeploymentDescription::
     ResourceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6326,7 +6252,7 @@ namespace DAnCE
 
     ArtifactDeploymentDescription::
     ArtifactDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6392,8 +6318,7 @@ namespace DAnCE
           ::XMLSchema::ID<ACE_TCHAR> t (a);
           id (t);
           std::basic_string<ACE_TCHAR> temp ((*id_).c_str());
-          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-          add_id(temp, dynamic_cast<XSCRT::Type*> (this));
+          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_id(temp, this);
         }
 
         else
@@ -6406,7 +6331,7 @@ namespace DAnCE
 
     MonolithicDeploymentDescription::
     MonolithicDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6460,8 +6385,7 @@ namespace DAnCE
           ::XMLSchema::ID<ACE_TCHAR> t (a);
           id (t);
           std::basic_string<ACE_TCHAR> temp ((*id_).c_str());
-          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-          add_id(temp, dynamic_cast<XSCRT::Type*> (this));
+          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_id(temp, this);
         }
 
         else
@@ -6514,7 +6438,7 @@ namespace DAnCE
 
     InstanceResourceDeploymentDescription::
     InstanceResourceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6558,7 +6482,7 @@ namespace DAnCE
 
     InstanceDeploymentDescription::
     InstanceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6624,8 +6548,7 @@ namespace DAnCE
           ::XMLSchema::ID<ACE_TCHAR> t (a);
           id (t);
           std::basic_string<ACE_TCHAR> temp ((*id_).c_str());
-          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-          add_id(temp, dynamic_cast<XSCRT::Type*> (this));
+          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_id(temp, this);
         }
 
         else
@@ -6687,7 +6610,7 @@ namespace DAnCE
 
     ComponentPortDescription::
     ComponentPortDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6761,7 +6684,7 @@ namespace DAnCE
 
     ComponentPropertyDescription::
     ComponentPropertyDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6793,7 +6716,7 @@ namespace DAnCE
 
     ComponentExternalPortEndpoint::
     ComponentExternalPortEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6819,7 +6742,7 @@ namespace DAnCE
 
     PlanSubcomponentPortEndpoint::
     PlanSubcomponentPortEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6863,7 +6786,7 @@ namespace DAnCE
 
     ExternalReferenceEndpoint::
     ExternalReferenceEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6907,7 +6830,7 @@ namespace DAnCE
 
     ConnectionResourceDeploymentDescription::
     ConnectionResourceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -6951,7 +6874,7 @@ namespace DAnCE
 
     PlanConnectionDescription::
     PlanConnectionDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -7013,7 +6936,7 @@ namespace DAnCE
 
     ImplementationDependency::
     ImplementationDependency (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -7039,7 +6962,7 @@ namespace DAnCE
 
     Capability::
     Capability (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -7077,7 +7000,7 @@ namespace DAnCE
 
     ImplementationRequirement::
     ImplementationRequirement (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -7133,7 +7056,7 @@ namespace DAnCE
 
     SubcomponentPortEndpoint::
     SubcomponentPortEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -7165,7 +7088,7 @@ namespace DAnCE
 
     AssemblyConnectionDescription::
     AssemblyConnectionDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -7249,7 +7172,7 @@ namespace DAnCE
 
     PlanLocality::
     PlanLocality (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/Basic_Deployment_Data.hpp
+++ b/tools/Config_Handlers/Basic_Deployment_Data.hpp
@@ -114,9 +114,6 @@ namespace DAnCE
       explicit IdRef (::XSCRT::XML::Element<ACE_TCHAR> const&);
       IdRef (IdRef const& s);
       IdRef& operator= (IdRef const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -293,9 +290,6 @@ namespace DAnCE
       explicit DataType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       DataType (DataType const& s);
       DataType& operator= (DataType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -552,9 +546,6 @@ namespace DAnCE
       explicit DataValue (::XSCRT::XML::Element<ACE_TCHAR> const&);
       DataValue (DataValue const& s);
       DataValue& operator= (DataValue const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -600,9 +591,6 @@ namespace DAnCE
       explicit AliasType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       AliasType (AliasType const& s);
       AliasType& operator= (AliasType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -655,9 +643,6 @@ namespace DAnCE
       explicit EnumType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       EnumType (EnumType const& s);
       EnumType& operator= (EnumType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -690,9 +675,6 @@ namespace DAnCE
       explicit BoundedStringType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       BoundedStringType (BoundedStringType const& s);
       BoundedStringType& operator= (BoundedStringType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -744,9 +726,6 @@ namespace DAnCE
       explicit StructType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       StructType (StructType const& s);
       StructType& operator= (StructType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -782,9 +761,6 @@ namespace DAnCE
       explicit StructMemberType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       StructMemberType (StructMemberType const& s);
       StructMemberType& operator= (StructMemberType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -856,9 +832,6 @@ namespace DAnCE
       explicit ValueType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ValueType (ValueType const& s);
       ValueType& operator= (ValueType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -904,9 +877,6 @@ namespace DAnCE
       explicit ValueMemberType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ValueMemberType (ValueMemberType const& s);
       ValueMemberType& operator= (ValueMemberType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -942,9 +912,6 @@ namespace DAnCE
       explicit NamedValue (::XSCRT::XML::Element<ACE_TCHAR> const&);
       NamedValue (NamedValue const& s);
       NamedValue& operator= (NamedValue const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -980,9 +947,6 @@ namespace DAnCE
       explicit ArrayType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ArrayType (ArrayType const& s);
       ArrayType& operator= (ArrayType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1018,9 +982,6 @@ namespace DAnCE
       explicit SequenceType (::XSCRT::XML::Element<ACE_TCHAR> const&);
       SequenceType (SequenceType const& s);
       SequenceType& operator= (SequenceType const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1056,9 +1017,6 @@ namespace DAnCE
       explicit Any (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Any (Any const& s);
       Any& operator= (Any const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1094,9 +1052,6 @@ namespace DAnCE
       explicit Property (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Property (Property const& s);
       Property& operator= (Property const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1191,9 +1146,6 @@ namespace DAnCE
       explicit SatisfierProperty (::XSCRT::XML::Element<ACE_TCHAR> const&);
       SatisfierProperty (SatisfierProperty const& s);
       SatisfierProperty& operator= (SatisfierProperty const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1252,9 +1204,6 @@ namespace DAnCE
       explicit Resource (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Resource (Resource const& s);
       Resource& operator= (Resource const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1306,9 +1255,6 @@ namespace DAnCE
       explicit Requirement (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Requirement (Requirement const& s);
       Requirement& operator= (Requirement const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1360,9 +1306,6 @@ namespace DAnCE
       explicit ResourceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ResourceDeploymentDescription (ResourceDeploymentDescription const& s);
       ResourceDeploymentDescription& operator= (ResourceDeploymentDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1489,9 +1432,6 @@ namespace DAnCE
       explicit ArtifactDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ArtifactDeploymentDescription (ArtifactDeploymentDescription const& s);
       ArtifactDeploymentDescription& operator= (ArtifactDeploymentDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1592,9 +1532,6 @@ namespace DAnCE
       explicit MonolithicDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       MonolithicDeploymentDescription (MonolithicDeploymentDescription const& s);
       MonolithicDeploymentDescription& operator= (MonolithicDeploymentDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1694,9 +1631,6 @@ namespace DAnCE
       explicit InstanceResourceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       InstanceResourceDeploymentDescription (InstanceResourceDeploymentDescription const& s);
       InstanceResourceDeploymentDescription& operator= (InstanceResourceDeploymentDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1805,9 +1739,6 @@ namespace DAnCE
       explicit InstanceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       InstanceDeploymentDescription (InstanceDeploymentDescription const& s);
       InstanceDeploymentDescription& operator= (InstanceDeploymentDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -1966,9 +1897,6 @@ namespace DAnCE
       explicit ComponentPortDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentPortDescription (ComponentPortDescription const& s);
       ComponentPortDescription& operator= (ComponentPortDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2004,9 +1932,6 @@ namespace DAnCE
       explicit ComponentPropertyDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentPropertyDescription (ComponentPropertyDescription const& s);
       ComponentPropertyDescription& operator= (ComponentPropertyDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2032,9 +1957,6 @@ namespace DAnCE
       explicit ComponentExternalPortEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentExternalPortEndpoint (ComponentExternalPortEndpoint const& s);
       ComponentExternalPortEndpoint& operator= (ComponentExternalPortEndpoint const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2090,9 +2012,6 @@ namespace DAnCE
       explicit PlanSubcomponentPortEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PlanSubcomponentPortEndpoint (PlanSubcomponentPortEndpoint const& s);
       PlanSubcomponentPortEndpoint& operator= (PlanSubcomponentPortEndpoint const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2154,9 +2073,6 @@ namespace DAnCE
       explicit ExternalReferenceEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ExternalReferenceEndpoint (ExternalReferenceEndpoint const& s);
       ExternalReferenceEndpoint& operator= (ExternalReferenceEndpoint const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2218,9 +2134,6 @@ namespace DAnCE
       explicit ConnectionResourceDeploymentDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ConnectionResourceDeploymentDescription (ConnectionResourceDeploymentDescription const& s);
       ConnectionResourceDeploymentDescription& operator= (ConnectionResourceDeploymentDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2336,9 +2249,6 @@ namespace DAnCE
       explicit PlanConnectionDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PlanConnectionDescription (PlanConnectionDescription const& s);
       PlanConnectionDescription& operator= (PlanConnectionDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2364,9 +2274,6 @@ namespace DAnCE
       explicit ImplementationDependency (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ImplementationDependency (ImplementationDependency const& s);
       ImplementationDependency& operator= (ImplementationDependency const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2424,9 +2331,6 @@ namespace DAnCE
       explicit Capability (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Capability (Capability const& s);
       Capability& operator= (Capability const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2508,9 +2412,6 @@ namespace DAnCE
       explicit ImplementationRequirement (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ImplementationRequirement (ImplementationRequirement const& s);
       ImplementationRequirement& operator= (ImplementationRequirement const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2546,9 +2447,6 @@ namespace DAnCE
       explicit SubcomponentPortEndpoint (::XSCRT::XML::Element<ACE_TCHAR> const&);
       SubcomponentPortEndpoint (SubcomponentPortEndpoint const& s);
       SubcomponentPortEndpoint& operator= (SubcomponentPortEndpoint const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2638,9 +2536,6 @@ namespace DAnCE
       explicit AssemblyConnectionDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       AssemblyConnectionDescription (AssemblyConnectionDescription const& s);
       AssemblyConnectionDescription& operator= (AssemblyConnectionDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -2719,9 +2614,6 @@ namespace DAnCE
       explicit PlanLocality (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PlanLocality (PlanLocality const& s);
       PlanLocality& operator= (PlanLocality const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/Deployment.cpp
+++ b/tools/Config_Handlers/Deployment.cpp
@@ -10,9 +10,9 @@
  */
 #include "Deployment.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE

--- a/tools/Config_Handlers/XMI.cpp
+++ b/tools/Config_Handlers/XMI.cpp
@@ -10,31 +10,29 @@
  */
 #include "XMI.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace XMI
 {
   // Extension
 
-  Extension::Extension () :
-  regulator__ ()
+  Extension::Extension ()
   {
   }
 
   Extension::Extension (Extension const& s) :
-  ::XSCRT::Type (s),
-  id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0),
-  label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-  uuid_ (s.uuid_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.uuid_) : 0),
-  href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-  idref_ (s.idref_.get () ? new ::XMLSchema::IDREF<ACE_TCHAR> (*s.idref_) : 0),
-  version_ (s.version_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.version_) : 0),
-  extender_ (s.extender_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.extender_) : 0),
-  extenderID_ (s.extenderID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.extenderID_) : 0),
-  regulator__ ()
+  ::XSCRT::Type (s)
+  , id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0)
+  , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+  , uuid_ (s.uuid_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.uuid_) : 0)
+  , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
+  , idref_ (s.idref_.get () ? new ::XMLSchema::IDREF<ACE_TCHAR> (*s.idref_) : 0)
+  , version_ (s.version_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.version_) : 0)
+  , extender_ (s.extender_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.extender_) : 0)
+  , extenderID_ (s.extenderID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.extenderID_) : 0)
   {
     if (id_.get ()) id_->container (this);
     if (label_.get ()) label_->container (this);
@@ -373,7 +371,7 @@ namespace XMI
 
   Extension::
   Extension (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-  :Base (e), regulator__ ()
+  :Base (e)
   {
 
     ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -387,8 +385,7 @@ namespace XMI
         ::XMLSchema::ID<ACE_TCHAR> t (a);
         id (t);
         std::basic_string<ACE_TCHAR> temp ((*id_).c_str());
-        (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-        add_id(temp, dynamic_cast<XSCRT::Type*> (this));
+        (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_id(temp, this);
       }
 
       else if (n == ACE_TEXT ("label"))
@@ -415,8 +412,7 @@ namespace XMI
         idref (t);
         std::basic_string<ACE_TCHAR> temp ((*idref_).id().c_str());
 
-        (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-        add_idref(temp, dynamic_cast<XSCRT::Type*> (this));
+        (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_idref(temp, this);
       }
 
       else if (n == ACE_TEXT ("version"))

--- a/tools/Config_Handlers/XMI.hpp
+++ b/tools/Config_Handlers/XMI.hpp
@@ -133,9 +133,6 @@ namespace XMI
     explicit Extension (::XSCRT::XML::Element<ACE_TCHAR> const&);
     Extension (Extension const& s);
     Extension& operator= (Extension const& s);
-
-    private:
-    char regulator__;
   };
 }
 

--- a/tools/Config_Handlers/ccd.cpp
+++ b/tools/Config_Handlers/ccd.cpp
@@ -10,9 +10,9 @@
  */
 #include "ccd.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -21,26 +21,24 @@ namespace DAnCE
   {
     // ComponentInterfaceDescription
 
-    ComponentInterfaceDescription::ComponentInterfaceDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ComponentInterfaceDescription::ComponentInterfaceDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ComponentInterfaceDescription::ComponentInterfaceDescription (ComponentInterfaceDescription const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    specificType_ (s.specificType_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.specificType_) : 0),
-    supportedType_ (s.supportedType_),
-    idlFile_ (s.idlFile_),
-    configProperty_ (s.configProperty_),
-    port_ (s.port_),
-    property_ (s.property_),
-    infoProperty_ (s.infoProperty_),
-    contentLocation_ (s.contentLocation_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.contentLocation_) : 0),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , specificType_ (s.specificType_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.specificType_) : 0)
+    , supportedType_ (s.supportedType_)
+    , idlFile_ (s.idlFile_)
+    , configProperty_ (s.configProperty_)
+    , port_ (s.port_)
+    , property_ (s.property_)
+    , infoProperty_ (s.infoProperty_)
+    , contentLocation_ (s.contentLocation_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.contentLocation_) : 0)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -472,7 +470,7 @@ namespace DAnCE
 
     ComponentInterfaceDescription::
     ComponentInterfaceDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/ccd.hpp
+++ b/tools/Config_Handlers/ccd.hpp
@@ -196,9 +196,6 @@ namespace DAnCE
       explicit ComponentInterfaceDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentInterfaceDescription (ComponentInterfaceDescription const& s);
       ComponentInterfaceDescription& operator= (ComponentInterfaceDescription const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/cdd.cpp
+++ b/tools/Config_Handlers/cdd.cpp
@@ -10,9 +10,9 @@
  */
 #include "cdd.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -21,23 +21,21 @@ namespace DAnCE
   {
     // Domain
 
-    Domain::Domain (node_container_type const& node__) :
-    ::XSCRT::Type (),
-    node_ (node__),
-    regulator__ ()
+    Domain::Domain (node_container_type const& node__)
+    : ::XSCRT::Type ()
+    , node_ (node__)
     {
     }
 
     Domain::Domain (Domain const& s) :
-    ::XSCRT::Type (s),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    node_ (s.node_),
-    interconnect_ (s.interconnect_),
-    bridge_ (s.bridge_),
-    sharedResource_ (s.sharedResource_),
-    infoProperty_ (s.infoProperty_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , node_ (s.node_)
+    , interconnect_ (s.interconnect_)
+    , bridge_ (s.bridge_)
+    , sharedResource_ (s.sharedResource_)
+    , infoProperty_ (s.infoProperty_)
     {
       if (UUID_.get ()) UUID_->container (this);
       if (label_.get ()) label_->container (this);
@@ -318,22 +316,20 @@ namespace DAnCE
     // Bridge
 
     Bridge::Bridge (::XMLSchema::string<ACE_TCHAR> const& name__,
-                    connect_container_type const& connect__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    connect_ (connect__),
-    regulator__ ()
+                    connect_container_type const& connect__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , connect_ (connect__)
     {
       name_->container (this);
     }
 
     Bridge::Bridge (Bridge const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    connect_ (s.connect_),
-    resource_ (s.resource_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , connect_ (s.connect_)
+    , resource_ (s.resource_)
     {
       name_->container (this);
       if (label_.get ()) label_->container (this);
@@ -479,23 +475,21 @@ namespace DAnCE
     // Interconnect
 
     Interconnect::Interconnect (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                connect_container_type const& connect__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    connect_ (connect__),
-    regulator__ ()
+                                connect_container_type const& connect__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , connect_ (connect__)
     {
       name_->container (this);
     }
 
     Interconnect::Interconnect (Interconnect const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    connection_ (s.connection_),
-    connect_ (s.connect_),
-    resource_ (s.resource_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , connection_ (s.connection_)
+    , connect_ (s.connect_)
+    , resource_ (s.resource_)
     {
       name_->container (this);
       if (label_.get ()) label_->container (this);
@@ -679,22 +673,20 @@ namespace DAnCE
 
     // Node
 
-    Node::Node (::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+    Node::Node (::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       name_->container (this);
     }
 
     Node::Node (Node const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    connection_ (s.connection_),
-    sharedResource_ (s.sharedResource_),
-    resource_ (s.resource_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , connection_ (s.connection_)
+    , sharedResource_ (s.sharedResource_)
+    , resource_ (s.resource_)
     {
       name_->container (this);
       if (label_.get ()) label_->container (this);
@@ -881,13 +873,12 @@ namespace DAnCE
     SharedResource::SharedResource (::XMLSchema::string<ACE_TCHAR> const& name__,
                                     ::XMLSchema::string<ACE_TCHAR> const& resourceType__,
                                     ::DAnCE::Config_Handlers::Node const& node__,
-                                    ::DAnCE::Config_Handlers::SatisfierProperty const& property__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (resourceType__)),
-    node_ (new ::DAnCE::Config_Handlers::Node (node__)),
-    property_ (new ::DAnCE::Config_Handlers::SatisfierProperty (property__)),
-    regulator__ ()
+                                    ::DAnCE::Config_Handlers::SatisfierProperty const& property__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (resourceType__))
+    , node_ (new ::DAnCE::Config_Handlers::Node (node__))
+    , property_ (new ::DAnCE::Config_Handlers::SatisfierProperty (property__))
     {
       name_->container (this);
       resourceType_->container (this);
@@ -896,12 +887,11 @@ namespace DAnCE
     }
 
     SharedResource::SharedResource (SharedResource const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceType_)),
-    node_ (new ::DAnCE::Config_Handlers::Node (*s.node_)),
-    property_ (new ::DAnCE::Config_Handlers::SatisfierProperty (*s.property_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , resourceType_ (new ::XMLSchema::string<ACE_TCHAR> (*s.resourceType_))
+    , node_ (new ::DAnCE::Config_Handlers::Node (*s.node_))
+    , property_ (new ::DAnCE::Config_Handlers::SatisfierProperty (*s.property_))
     {
       name_->container (this);
       resourceType_->container (this);
@@ -989,7 +979,7 @@ namespace DAnCE
 
     Domain::
     Domain (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -1051,7 +1041,7 @@ namespace DAnCE
 
     Bridge::
     Bridge (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -1095,7 +1085,7 @@ namespace DAnCE
 
     Interconnect::
     Interconnect (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -1145,7 +1135,7 @@ namespace DAnCE
 
     Node::
     Node (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -1195,7 +1185,7 @@ namespace DAnCE
 
     SharedResource::
     SharedResource (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/cdd.hpp
+++ b/tools/Config_Handlers/cdd.hpp
@@ -153,9 +153,6 @@ namespace DAnCE
       explicit Domain (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Domain (Domain const& s);
       Domain& operator= (Domain const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -224,9 +221,6 @@ namespace DAnCE
       explicit Bridge (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Bridge (Bridge const& s);
       Bridge& operator= (Bridge const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -311,9 +305,6 @@ namespace DAnCE
       explicit Interconnect (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Interconnect (Interconnect const& s);
       Interconnect& operator= (Interconnect const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -397,9 +388,6 @@ namespace DAnCE
       explicit Node (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Node (Node const& s);
       Node& operator= (Node const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -455,9 +443,6 @@ namespace DAnCE
       explicit SharedResource (::XSCRT::XML::Element<ACE_TCHAR> const&);
       SharedResource (SharedResource const& s);
       SharedResource& operator= (SharedResource const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/cdp.cpp
+++ b/tools/Config_Handlers/cdp.cpp
@@ -10,9 +10,9 @@
  */
 #include "cdp.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -22,21 +22,19 @@ namespace DAnCE
     // PlanSubcomponentPropertyReference
 
     PlanSubcomponentPropertyReference::PlanSubcomponentPropertyReference (::XMLSchema::string<ACE_TCHAR> const& propertyName__,
-                                                                          ::DAnCE::Config_Handlers::InstanceDeploymentDescription const& instance__) :
-    ::XSCRT::Type (),
-    propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (propertyName__)),
-    instance_ (new ::DAnCE::Config_Handlers::InstanceDeploymentDescription (instance__)),
-    regulator__ ()
+                                                                          ::DAnCE::Config_Handlers::InstanceDeploymentDescription const& instance__)
+    : ::XSCRT::Type ()
+    , propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (propertyName__))
+    , instance_ (new ::DAnCE::Config_Handlers::InstanceDeploymentDescription (instance__))
     {
       propertyName_->container (this);
       instance_->container (this);
     }
 
     PlanSubcomponentPropertyReference::PlanSubcomponentPropertyReference (PlanSubcomponentPropertyReference const& s) :
-    ::XSCRT::Type (s),
-    propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.propertyName_)),
-    instance_ (new ::DAnCE::Config_Handlers::InstanceDeploymentDescription (*s.instance_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.propertyName_))
+    , instance_ (new ::DAnCE::Config_Handlers::InstanceDeploymentDescription (*s.instance_))
     {
       propertyName_->container (this);
       instance_->container (this);
@@ -87,24 +85,22 @@ namespace DAnCE
 
     PlanPropertyMapping::PlanPropertyMapping (::XMLSchema::string<ACE_TCHAR> const& name__,
                                               ::XMLSchema::string<ACE_TCHAR> const& externalName__,
-                                              delegatesTo_container_type const& delegatesTo__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    externalName_ (new ::XMLSchema::string<ACE_TCHAR> (externalName__)),
-    delegatesTo_ (delegatesTo__),
-    regulator__ ()
+                                              delegatesTo_container_type const& delegatesTo__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , externalName_ (new ::XMLSchema::string<ACE_TCHAR> (externalName__))
+    , delegatesTo_ (delegatesTo__)
     {
       name_->container (this);
       externalName_->container (this);
     }
 
     PlanPropertyMapping::PlanPropertyMapping (PlanPropertyMapping const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    source_ (s.source_),
-    externalName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.externalName_)),
-    delegatesTo_ (s.delegatesTo_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , source_ (s.source_)
+    , externalName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.externalName_))
+    , delegatesTo_ (s.delegatesTo_)
     {
       name_->container (this);
       externalName_->container (this);
@@ -231,26 +227,24 @@ namespace DAnCE
 
     // deploymentPlan
 
-    deploymentPlan::deploymentPlan () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    deploymentPlan::deploymentPlan ()
+    : ::XSCRT::Type ()
     {
     }
 
     deploymentPlan::deploymentPlan (deploymentPlan const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    realizes_ (s.realizes_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.realizes_) : 0),
-    implementation_ (s.implementation_),
-    instance_ (s.instance_),
-    connection_ (s.connection_),
-    externalProperty_ (s.externalProperty_),
-    dependsOn_ (s.dependsOn_),
-    artifact_ (s.artifact_),
-    infoProperty_ (s.infoProperty_),
-    localityConstraint_ (s.localityConstraint_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , realizes_ (s.realizes_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.realizes_) : 0)
+    , implementation_ (s.implementation_)
+    , instance_ (s.instance_)
+    , connection_ (s.connection_)
+    , externalProperty_ (s.externalProperty_)
+    , dependsOn_ (s.dependsOn_)
+    , artifact_ (s.artifact_)
+    , infoProperty_ (s.infoProperty_)
+    , localityConstraint_ (s.localityConstraint_)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -688,7 +682,7 @@ namespace DAnCE
 
     PlanSubcomponentPropertyReference::
     PlanSubcomponentPropertyReference (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -720,7 +714,7 @@ namespace DAnCE
 
     PlanPropertyMapping::
     PlanPropertyMapping (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -764,7 +758,7 @@ namespace DAnCE
 
     deploymentPlan::
     deploymentPlan (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/cdp.hpp
+++ b/tools/Config_Handlers/cdp.hpp
@@ -70,9 +70,6 @@ namespace DAnCE
       explicit PlanSubcomponentPropertyReference (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PlanSubcomponentPropertyReference (PlanSubcomponentPropertyReference const& s);
       PlanSubcomponentPropertyReference& operator= (PlanSubcomponentPropertyReference const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -141,9 +138,6 @@ namespace DAnCE
       explicit PlanPropertyMapping (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PlanPropertyMapping (PlanPropertyMapping const& s);
       PlanPropertyMapping& operator= (PlanPropertyMapping const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -318,9 +312,6 @@ namespace DAnCE
       explicit deploymentPlan (::XSCRT::XML::Element<ACE_TCHAR> const&);
       deploymentPlan (deploymentPlan const& s);
       deploymentPlan& operator= (deploymentPlan const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/cid.cpp
+++ b/tools/Config_Handlers/cid.cpp
@@ -10,9 +10,9 @@
  */
 #include "cid.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -21,20 +21,18 @@ namespace DAnCE
   {
     // ComponentPackageReference
 
-    ComponentPackageReference::ComponentPackageReference (::DAnCE::Config_Handlers::ComponentInterfaceDescription const& requiredType__) :
-    ::XSCRT::Type (),
-    requiredType_ (new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (requiredType__)),
-    regulator__ ()
+    ComponentPackageReference::ComponentPackageReference (::DAnCE::Config_Handlers::ComponentInterfaceDescription const& requiredType__)
+    : ::XSCRT::Type ()
+    , requiredType_ (new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (requiredType__))
     {
       requiredType_->container (this);
     }
 
     ComponentPackageReference::ComponentPackageReference (ComponentPackageReference const& s) :
-    ::XSCRT::Type (s),
-    requiredUUID_ (s.requiredUUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.requiredUUID_) : 0),
-    requiredName_ (s.requiredName_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.requiredName_) : 0),
-    requiredType_ (new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.requiredType_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , requiredUUID_ (s.requiredUUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.requiredUUID_) : 0)
+    , requiredName_ (s.requiredName_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.requiredName_) : 0)
+    , requiredType_ (new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.requiredType_))
     {
       if (requiredUUID_.get ()) requiredUUID_->container (this);
       if (requiredName_.get ()) requiredName_->container (this);
@@ -135,25 +133,23 @@ namespace DAnCE
 
     // SubcomponentInstantiationDescription
 
-    SubcomponentInstantiationDescription::SubcomponentInstantiationDescription (::XMLSchema::string<ACE_TCHAR> const& name__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    regulator__ ()
+    SubcomponentInstantiationDescription::SubcomponentInstantiationDescription (::XMLSchema::string<ACE_TCHAR> const& name__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
     {
       name_->container (this);
     }
 
     SubcomponentInstantiationDescription::SubcomponentInstantiationDescription (SubcomponentInstantiationDescription const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    basePackage_ (s.basePackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageDescription (*s.basePackage_) : 0),
-    specializedConfig_ (s.specializedConfig_.get () ? new ::DAnCE::Config_Handlers::PackageConfiguration (*s.specializedConfig_) : 0),
-    selectRequirement_ (s.selectRequirement_),
-    configProperty_ (s.configProperty_),
-    referencedPackage_ (s.referencedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageReference (*s.referencedPackage_) : 0),
-    importedPackage_ (s.importedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageImport (*s.importedPackage_) : 0),
-    id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , basePackage_ (s.basePackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageDescription (*s.basePackage_) : 0)
+    , specializedConfig_ (s.specializedConfig_.get () ? new ::DAnCE::Config_Handlers::PackageConfiguration (*s.specializedConfig_) : 0)
+    , selectRequirement_ (s.selectRequirement_)
+    , configProperty_ (s.configProperty_)
+    , referencedPackage_ (s.referencedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageReference (*s.referencedPackage_) : 0)
+    , importedPackage_ (s.importedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageImport (*s.importedPackage_) : 0)
+    , id_ (s.id_.get () ? new ::XMLSchema::ID<ACE_TCHAR> (*s.id_) : 0)
     {
       name_->container (this);
       if (basePackage_.get ()) basePackage_->container (this);
@@ -439,21 +435,19 @@ namespace DAnCE
     // SubcomponentPropertyReference
 
     SubcomponentPropertyReference::SubcomponentPropertyReference (::XMLSchema::string<ACE_TCHAR> const& propertyName__,
-                                                                  ::DAnCE::Config_Handlers::IdRef const& instance__) :
-    ::XSCRT::Type (),
-    propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (propertyName__)),
-    instance_ (new ::DAnCE::Config_Handlers::IdRef (instance__)),
-    regulator__ ()
+                                                                  ::DAnCE::Config_Handlers::IdRef const& instance__)
+    : ::XSCRT::Type ()
+    , propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (propertyName__))
+    , instance_ (new ::DAnCE::Config_Handlers::IdRef (instance__))
     {
       propertyName_->container (this);
       instance_->container (this);
     }
 
     SubcomponentPropertyReference::SubcomponentPropertyReference (SubcomponentPropertyReference const& s) :
-    ::XSCRT::Type (s),
-    propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.propertyName_)),
-    instance_ (new ::DAnCE::Config_Handlers::IdRef (*s.instance_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , propertyName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.propertyName_))
+    , instance_ (new ::DAnCE::Config_Handlers::IdRef (*s.instance_))
     {
       propertyName_->container (this);
       instance_->container (this);
@@ -503,22 +497,20 @@ namespace DAnCE
     // AssemblyPropertyMapping
 
     AssemblyPropertyMapping::AssemblyPropertyMapping (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                                      ::XMLSchema::string<ACE_TCHAR> const& externalName__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    externalName_ (new ::XMLSchema::string<ACE_TCHAR> (externalName__)),
-    regulator__ ()
+                                                      ::XMLSchema::string<ACE_TCHAR> const& externalName__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , externalName_ (new ::XMLSchema::string<ACE_TCHAR> (externalName__))
     {
       name_->container (this);
       externalName_->container (this);
     }
 
     AssemblyPropertyMapping::AssemblyPropertyMapping (AssemblyPropertyMapping const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    externalName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.externalName_)),
-    delegatesTo_ (s.delegatesTo_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , externalName_ (new ::XMLSchema::string<ACE_TCHAR> (*s.externalName_))
+    , delegatesTo_ (s.delegatesTo_)
     {
       name_->container (this);
       externalName_->container (this);
@@ -633,21 +625,19 @@ namespace DAnCE
     // Locality
 
     Locality::Locality (::DAnCE::Config_Handlers::LocalityKind const& constraint__,
-                        ::DAnCE::Config_Handlers::IdRef const& constrainedInstance__) :
-    ::XSCRT::Type (),
-    constraint_ (new ::DAnCE::Config_Handlers::LocalityKind (constraint__)),
-    constrainedInstance_ (new ::DAnCE::Config_Handlers::IdRef (constrainedInstance__)),
-    regulator__ ()
+                        ::DAnCE::Config_Handlers::IdRef const& constrainedInstance__)
+    : ::XSCRT::Type ()
+    , constraint_ (new ::DAnCE::Config_Handlers::LocalityKind (constraint__))
+    , constrainedInstance_ (new ::DAnCE::Config_Handlers::IdRef (constrainedInstance__))
     {
       constraint_->container (this);
       constrainedInstance_->container (this);
     }
 
     Locality::Locality (Locality const& s) :
-    ::XSCRT::Type (s),
-    constraint_ (new ::DAnCE::Config_Handlers::LocalityKind (*s.constraint_)),
-    constrainedInstance_ (new ::DAnCE::Config_Handlers::IdRef (*s.constrainedInstance_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , constraint_ (new ::DAnCE::Config_Handlers::LocalityKind (*s.constraint_))
+    , constrainedInstance_ (new ::DAnCE::Config_Handlers::IdRef (*s.constrainedInstance_))
     {
       constraint_->container (this);
       constrainedInstance_->container (this);
@@ -696,19 +686,17 @@ namespace DAnCE
 
     // ComponentAssemblyDescription
 
-    ComponentAssemblyDescription::ComponentAssemblyDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ComponentAssemblyDescription::ComponentAssemblyDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ComponentAssemblyDescription::ComponentAssemblyDescription (ComponentAssemblyDescription const& s) :
-    ::XSCRT::Type (s),
-    instance_ (s.instance_),
-    connection_ (s.connection_),
-    externalProperty_ (s.externalProperty_),
-    locality_ (s.locality_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , instance_ (s.instance_)
+    , connection_ (s.connection_)
+    , externalProperty_ (s.externalProperty_)
+    , locality_ (s.locality_)
     {
     }
 
@@ -881,19 +869,17 @@ namespace DAnCE
 
     // MonolithicImplementationDescription
 
-    MonolithicImplementationDescription::MonolithicImplementationDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    MonolithicImplementationDescription::MonolithicImplementationDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     MonolithicImplementationDescription::MonolithicImplementationDescription (MonolithicImplementationDescription const& s) :
-    ::XSCRT::Type (s),
-    nodeExecParameter_ (s.nodeExecParameter_),
-    componentExecParameter_ (s.componentExecParameter_),
-    deployRequirement_ (s.deployRequirement_),
-    primaryArtifact_ (s.primaryArtifact_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , nodeExecParameter_ (s.nodeExecParameter_)
+    , componentExecParameter_ (s.componentExecParameter_)
+    , deployRequirement_ (s.deployRequirement_)
+    , primaryArtifact_ (s.primaryArtifact_)
     {
     }
 
@@ -1066,25 +1052,23 @@ namespace DAnCE
 
     // ComponentImplementationDescription
 
-    ComponentImplementationDescription::ComponentImplementationDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ComponentImplementationDescription::ComponentImplementationDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ComponentImplementationDescription::ComponentImplementationDescription (ComponentImplementationDescription const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    implements_ (s.implements_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.implements_) : 0),
-    assemblyImpl_ (s.assemblyImpl_.get () ? new ::DAnCE::Config_Handlers::ComponentAssemblyDescription (*s.assemblyImpl_) : 0),
-    monolithicImpl_ (s.monolithicImpl_.get () ? new ::DAnCE::Config_Handlers::MonolithicImplementationDescription (*s.monolithicImpl_) : 0),
-    configProperty_ (s.configProperty_),
-    capability_ (s.capability_),
-    dependsOn_ (s.dependsOn_),
-    infoProperty_ (s.infoProperty_),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , implements_ (s.implements_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.implements_) : 0)
+    , assemblyImpl_ (s.assemblyImpl_.get () ? new ::DAnCE::Config_Handlers::ComponentAssemblyDescription (*s.assemblyImpl_) : 0)
+    , monolithicImpl_ (s.monolithicImpl_.get () ? new ::DAnCE::Config_Handlers::MonolithicImplementationDescription (*s.monolithicImpl_) : 0)
+    , configProperty_ (s.configProperty_)
+    , capability_ (s.capability_)
+    , dependsOn_ (s.dependsOn_)
+    , infoProperty_ (s.infoProperty_)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -1465,25 +1449,23 @@ namespace DAnCE
 
     // ConnectorImplementationDescription
 
-    ConnectorImplementationDescription::ConnectorImplementationDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ConnectorImplementationDescription::ConnectorImplementationDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ConnectorImplementationDescription::ConnectorImplementationDescription (ConnectorImplementationDescription const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    implements_ (s.implements_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.implements_) : 0),
-    assemblyImpl_ (s.assemblyImpl_.get () ? new ::DAnCE::Config_Handlers::ComponentAssemblyDescription (*s.assemblyImpl_) : 0),
-    monolithicImpl_ (s.monolithicImpl_.get () ? new ::DAnCE::Config_Handlers::MonolithicImplementationDescription (*s.monolithicImpl_) : 0),
-    configProperty_ (s.configProperty_),
-    capability_ (s.capability_),
-    dependsOn_ (s.dependsOn_),
-    infoProperty_ (s.infoProperty_),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , implements_ (s.implements_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.implements_) : 0)
+    , assemblyImpl_ (s.assemblyImpl_.get () ? new ::DAnCE::Config_Handlers::ComponentAssemblyDescription (*s.assemblyImpl_) : 0)
+    , monolithicImpl_ (s.monolithicImpl_.get () ? new ::DAnCE::Config_Handlers::MonolithicImplementationDescription (*s.monolithicImpl_) : 0)
+    , configProperty_ (s.configProperty_)
+    , capability_ (s.capability_)
+    , dependsOn_ (s.dependsOn_)
+    , infoProperty_ (s.infoProperty_)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -1871,7 +1853,7 @@ namespace DAnCE
 
     ComponentPackageReference::
     ComponentPackageReference (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -1909,7 +1891,7 @@ namespace DAnCE
 
     SubcomponentInstantiationDescription::
     SubcomponentInstantiationDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -1975,8 +1957,7 @@ namespace DAnCE
           ::XMLSchema::ID<ACE_TCHAR> t (a);
           id (t);
           std::basic_string<ACE_TCHAR> temp ((*id_).c_str());
-          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->
-          add_id(temp, dynamic_cast<XSCRT::Type*> (this));
+          (*ACE_Singleton<ID_Map::TSS_ID_Map, ACE_Null_Mutex>::instance())->add_id(temp, this);
         }
 
         else
@@ -1989,7 +1970,7 @@ namespace DAnCE
 
     SubcomponentPropertyReference::
     SubcomponentPropertyReference (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -2021,7 +2002,7 @@ namespace DAnCE
 
     AssemblyPropertyMapping::
     AssemblyPropertyMapping (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -2102,7 +2083,7 @@ namespace DAnCE
 
     Locality::
     Locality (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -2134,7 +2115,7 @@ namespace DAnCE
 
     ComponentAssemblyDescription::
     ComponentAssemblyDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -2178,7 +2159,7 @@ namespace DAnCE
 
     MonolithicImplementationDescription::
     MonolithicImplementationDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -2222,7 +2203,7 @@ namespace DAnCE
 
     ComponentImplementationDescription::
     ComponentImplementationDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -2311,7 +2292,7 @@ namespace DAnCE
 
     ConnectorImplementationDescription::
     ConnectorImplementationDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/cid.hpp
+++ b/tools/Config_Handlers/cid.hpp
@@ -93,9 +93,6 @@ namespace DAnCE
       explicit ComponentPackageReference (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentPackageReference (ComponentPackageReference const& s);
       ComponentPackageReference& operator= (ComponentPackageReference const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -204,9 +201,6 @@ namespace DAnCE
       explicit SubcomponentInstantiationDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       SubcomponentInstantiationDescription (SubcomponentInstantiationDescription const& s);
       SubcomponentInstantiationDescription& operator= (SubcomponentInstantiationDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -242,9 +236,6 @@ namespace DAnCE
       explicit SubcomponentPropertyReference (::XSCRT::XML::Element<ACE_TCHAR> const&);
       SubcomponentPropertyReference (SubcomponentPropertyReference const& s);
       SubcomponentPropertyReference& operator= (SubcomponentPropertyReference const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -296,9 +287,6 @@ namespace DAnCE
       explicit AssemblyPropertyMapping (::XSCRT::XML::Element<ACE_TCHAR> const&);
       AssemblyPropertyMapping (AssemblyPropertyMapping const& s);
       AssemblyPropertyMapping& operator= (AssemblyPropertyMapping const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -373,9 +361,6 @@ namespace DAnCE
       explicit Locality (::XSCRT::XML::Element<ACE_TCHAR> const&);
       Locality (Locality const& s);
       Locality& operator= (Locality const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -456,9 +441,6 @@ namespace DAnCE
       explicit ComponentAssemblyDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentAssemblyDescription (ComponentAssemblyDescription const& s);
       ComponentAssemblyDescription& operator= (ComponentAssemblyDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -539,9 +521,6 @@ namespace DAnCE
       explicit MonolithicImplementationDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       MonolithicImplementationDescription (MonolithicImplementationDescription const& s);
       MonolithicImplementationDescription& operator= (MonolithicImplementationDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -683,9 +662,6 @@ namespace DAnCE
       explicit ComponentImplementationDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentImplementationDescription (ComponentImplementationDescription const& s);
       ComponentImplementationDescription& operator= (ComponentImplementationDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -827,9 +803,6 @@ namespace DAnCE
       explicit ConnectorImplementationDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ConnectorImplementationDescription (ConnectorImplementationDescription const& s);
       ConnectorImplementationDescription& operator= (ConnectorImplementationDescription const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/cpd.cpp
+++ b/tools/Config_Handlers/cpd.cpp
@@ -10,9 +10,9 @@
  */
 #include "cpd.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -22,21 +22,19 @@ namespace DAnCE
     // PackagedComponentImplementation
 
     PackagedComponentImplementation::PackagedComponentImplementation (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                                                      ::DAnCE::Config_Handlers::ComponentImplementationDescription const& referencedImplementation__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    referencedImplementation_ (new ::DAnCE::Config_Handlers::ComponentImplementationDescription (referencedImplementation__)),
-    regulator__ ()
+                                                                      ::DAnCE::Config_Handlers::ComponentImplementationDescription const& referencedImplementation__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , referencedImplementation_ (new ::DAnCE::Config_Handlers::ComponentImplementationDescription (referencedImplementation__))
     {
       name_->container (this);
       referencedImplementation_->container (this);
     }
 
     PackagedComponentImplementation::PackagedComponentImplementation (PackagedComponentImplementation const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    referencedImplementation_ (new ::DAnCE::Config_Handlers::ComponentImplementationDescription (*s.referencedImplementation_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , referencedImplementation_ (new ::DAnCE::Config_Handlers::ComponentImplementationDescription (*s.referencedImplementation_))
     {
       name_->container (this);
       referencedImplementation_->container (this);
@@ -85,22 +83,20 @@ namespace DAnCE
 
     // ComponentPackageDescription
 
-    ComponentPackageDescription::ComponentPackageDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ComponentPackageDescription::ComponentPackageDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ComponentPackageDescription::ComponentPackageDescription (ComponentPackageDescription const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    realizes_ (s.realizes_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.realizes_) : 0),
-    configProperty_ (s.configProperty_),
-    implementation_ (s.implementation_),
-    infoProperty_ (s.infoProperty_),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , realizes_ (s.realizes_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.realizes_) : 0)
+    , configProperty_ (s.configProperty_)
+    , implementation_ (s.implementation_)
+    , infoProperty_ (s.infoProperty_)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -374,22 +370,20 @@ namespace DAnCE
 
     // ConnectorPackageDescription
 
-    ConnectorPackageDescription::ConnectorPackageDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ConnectorPackageDescription::ConnectorPackageDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ConnectorPackageDescription::ConnectorPackageDescription (ConnectorPackageDescription const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    realizes_ (s.realizes_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.realizes_) : 0),
-    configProperty_ (s.configProperty_),
-    implementation_ (s.implementation_),
-    infoProperty_ (s.infoProperty_),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , realizes_ (s.realizes_.get () ? new ::DAnCE::Config_Handlers::ComponentInterfaceDescription (*s.realizes_) : 0)
+    , configProperty_ (s.configProperty_)
+    , implementation_ (s.implementation_)
+    , infoProperty_ (s.infoProperty_)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -670,7 +664,7 @@ namespace DAnCE
 
     PackagedComponentImplementation::
     PackagedComponentImplementation (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -702,7 +696,7 @@ namespace DAnCE
 
     ComponentPackageDescription::
     ComponentPackageDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -773,7 +767,7 @@ namespace DAnCE
 
     ConnectorPackageDescription::
     ConnectorPackageDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/cpd.hpp
+++ b/tools/Config_Handlers/cpd.hpp
@@ -70,9 +70,6 @@ namespace DAnCE
       explicit PackagedComponentImplementation (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PackagedComponentImplementation (PackagedComponentImplementation const& s);
       PackagedComponentImplementation& operator= (PackagedComponentImplementation const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -178,9 +175,6 @@ namespace DAnCE
       explicit ComponentPackageDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentPackageDescription (ComponentPackageDescription const& s);
       ComponentPackageDescription& operator= (ComponentPackageDescription const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -286,9 +280,6 @@ namespace DAnCE
       explicit ConnectorPackageDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ConnectorPackageDescription (ConnectorPackageDescription const& s);
       ConnectorPackageDescription& operator= (ConnectorPackageDescription const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/iad.cpp
+++ b/tools/Config_Handlers/iad.cpp
@@ -10,9 +10,9 @@
  */
 #include "iad.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -22,21 +22,19 @@ namespace DAnCE
     // NamedImplementationArtifact
 
     NamedImplementationArtifact::NamedImplementationArtifact (::XMLSchema::string<ACE_TCHAR> const& name__,
-                                                              ::DAnCE::Config_Handlers::ImplementationArtifactDescription const& referencedArtifact__) :
-    ::XSCRT::Type (),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (name__)),
-    referencedArtifact_ (new ::DAnCE::Config_Handlers::ImplementationArtifactDescription (referencedArtifact__)),
-    regulator__ ()
+                                                              ::DAnCE::Config_Handlers::ImplementationArtifactDescription const& referencedArtifact__)
+    : ::XSCRT::Type ()
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (name__))
+    , referencedArtifact_ (new ::DAnCE::Config_Handlers::ImplementationArtifactDescription (referencedArtifact__))
     {
       name_->container (this);
       referencedArtifact_->container (this);
     }
 
     NamedImplementationArtifact::NamedImplementationArtifact (NamedImplementationArtifact const& s) :
-    ::XSCRT::Type (s),
-    name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_)),
-    referencedArtifact_ (new ::DAnCE::Config_Handlers::ImplementationArtifactDescription (*s.referencedArtifact_)),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , name_ (new ::XMLSchema::string<ACE_TCHAR> (*s.name_))
+    , referencedArtifact_ (new ::DAnCE::Config_Handlers::ImplementationArtifactDescription (*s.referencedArtifact_))
     {
       name_->container (this);
       referencedArtifact_->container (this);
@@ -85,24 +83,22 @@ namespace DAnCE
 
     // ImplementationArtifactDescription
 
-    ImplementationArtifactDescription::ImplementationArtifactDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ImplementationArtifactDescription::ImplementationArtifactDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     ImplementationArtifactDescription::ImplementationArtifactDescription (ImplementationArtifactDescription const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    location_ (s.location_),
-    dependsOn_ (s.dependsOn_),
-    execParameter_ (s.execParameter_),
-    infoProperty_ (s.infoProperty_),
-    deployRequirement_ (s.deployRequirement_),
-    contentLocation_ (s.contentLocation_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.contentLocation_) : 0),
-    href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , location_ (s.location_)
+    , dependsOn_ (s.dependsOn_)
+    , execParameter_ (s.execParameter_)
+    , infoProperty_ (s.infoProperty_)
+    , deployRequirement_ (s.deployRequirement_)
+    , contentLocation_ (s.contentLocation_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.contentLocation_) : 0)
+    , href_ (s.href_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.href_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -461,7 +457,7 @@ namespace DAnCE
 
     NamedImplementationArtifact::
     NamedImplementationArtifact (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -493,7 +489,7 @@ namespace DAnCE
 
     ImplementationArtifactDescription::
     ImplementationArtifactDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/iad.hpp
+++ b/tools/Config_Handlers/iad.hpp
@@ -69,9 +69,6 @@ namespace DAnCE
       explicit NamedImplementationArtifact (::XSCRT::XML::Element<ACE_TCHAR> const&);
       NamedImplementationArtifact (NamedImplementationArtifact const& s);
       NamedImplementationArtifact& operator= (NamedImplementationArtifact const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -209,9 +206,6 @@ namespace DAnCE
       explicit ImplementationArtifactDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ImplementationArtifactDescription (ImplementationArtifactDescription const& s);
       ImplementationArtifactDescription& operator= (ImplementationArtifactDescription const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/pcd.cpp
+++ b/tools/Config_Handlers/pcd.cpp
@@ -10,9 +10,9 @@
  */
 #include "pcd.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -21,16 +21,14 @@ namespace DAnCE
   {
     // ComponentPackageImport
 
-    ComponentPackageImport::ComponentPackageImport () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    ComponentPackageImport::ComponentPackageImport ()
+    : ::XSCRT::Type ()
     {
     }
 
     ComponentPackageImport::ComponentPackageImport (ComponentPackageImport const& s) :
-    ::XSCRT::Type (s),
-    location_ (s.location_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , location_ (s.location_)
     {
     }
 
@@ -86,24 +84,22 @@ namespace DAnCE
 
     // PackageConfiguration
 
-    PackageConfiguration::PackageConfiguration () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    PackageConfiguration::PackageConfiguration ()
+    : ::XSCRT::Type ()
     {
     }
 
     PackageConfiguration::PackageConfiguration (PackageConfiguration const& s) :
-    ::XSCRT::Type (s),
-    label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0),
-    UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0),
-    basePackage_ (s.basePackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageDescription (*s.basePackage_) : 0),
-    specializedConfig_ (s.specializedConfig_.get () ? new ::DAnCE::Config_Handlers::PackageConfiguration (*s.specializedConfig_) : 0),
-    importedPackage_ (s.importedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageImport (*s.importedPackage_) : 0),
-    referencedPackage_ (s.referencedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageReference (*s.referencedPackage_) : 0),
-    selectRequirement_ (s.selectRequirement_),
-    configProperty_ (s.configProperty_),
-    contentLocation_ (s.contentLocation_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.contentLocation_) : 0),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , label_ (s.label_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.label_) : 0)
+    , UUID_ (s.UUID_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.UUID_) : 0)
+    , basePackage_ (s.basePackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageDescription (*s.basePackage_) : 0)
+    , specializedConfig_ (s.specializedConfig_.get () ? new ::DAnCE::Config_Handlers::PackageConfiguration (*s.specializedConfig_) : 0)
+    , importedPackage_ (s.importedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageImport (*s.importedPackage_) : 0)
+    , referencedPackage_ (s.referencedPackage_.get () ? new ::DAnCE::Config_Handlers::ComponentPackageReference (*s.referencedPackage_) : 0)
+    , selectRequirement_ (s.selectRequirement_)
+    , configProperty_ (s.configProperty_)
+    , contentLocation_ (s.contentLocation_.get () ? new ::XMLSchema::string<ACE_TCHAR> (*s.contentLocation_) : 0)
     {
       if (label_.get ()) label_->container (this);
       if (UUID_.get ()) UUID_->container (this);
@@ -443,7 +439,7 @@ namespace DAnCE
 
     ComponentPackageImport::
     ComponentPackageImport (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);
@@ -469,7 +465,7 @@ namespace DAnCE
 
     PackageConfiguration::
     PackageConfiguration (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/pcd.hpp
+++ b/tools/Config_Handlers/pcd.hpp
@@ -68,9 +68,6 @@ namespace DAnCE
       explicit ComponentPackageImport (::XSCRT::XML::Element<ACE_TCHAR> const&);
       ComponentPackageImport (ComponentPackageImport const& s);
       ComponentPackageImport& operator= (ComponentPackageImport const& s);
-
-      private:
-      char regulator__;
     };
 
 
@@ -189,9 +186,6 @@ namespace DAnCE
       explicit PackageConfiguration (::XSCRT::XML::Element<ACE_TCHAR> const&);
       PackageConfiguration (PackageConfiguration const& s);
       PackageConfiguration& operator= (PackageConfiguration const& s);
-
-      private:
-      char regulator__;
     };
   }
 }

--- a/tools/Config_Handlers/toplevel.cpp
+++ b/tools/Config_Handlers/toplevel.cpp
@@ -10,9 +10,9 @@
  */
 #include "toplevel.hpp"
 
+#include "ace/ace_wchar.h"
 #include "ace/Null_Mutex.h"
 #include "ace/TSS_T.h"
-#include "ace/ace_wchar.h"
 #include "ace/Singleton.h"
 
 namespace DAnCE
@@ -21,16 +21,14 @@ namespace DAnCE
   {
     // TopLevelPackageDescription
 
-    TopLevelPackageDescription::TopLevelPackageDescription () :
-    ::XSCRT::Type (),
-    regulator__ ()
+    TopLevelPackageDescription::TopLevelPackageDescription ()
+    : ::XSCRT::Type ()
     {
     }
 
     TopLevelPackageDescription::TopLevelPackageDescription (TopLevelPackageDescription const& s) :
-    ::XSCRT::Type (s),
-    package_ (s.package_),
-    regulator__ ()
+    ::XSCRT::Type (s)
+    , package_ (s.package_)
     {
     }
 
@@ -93,7 +91,7 @@ namespace DAnCE
 
     TopLevelPackageDescription::
     TopLevelPackageDescription (::XSCRT::XML::Element<ACE_TCHAR> const& e)
-    :Base (e), regulator__ ()
+    :Base (e)
     {
 
       ::XSCRT::Parser<ACE_TCHAR> p (e);

--- a/tools/Config_Handlers/toplevel.hpp
+++ b/tools/Config_Handlers/toplevel.hpp
@@ -65,9 +65,6 @@ namespace DAnCE
       explicit TopLevelPackageDescription (::XSCRT::XML::Element<ACE_TCHAR> const&);
       TopLevelPackageDescription (TopLevelPackageDescription const& s);
       TopLevelPackageDescription& operator= (TopLevelPackageDescription const& s);
-
-      private:
-      char regulator__;
     };
   }
 }


### PR DESCRIPTION
…ration code

    * tools/Config_Handlers/Basic_Deployment_Data.cpp:
    * tools/Config_Handlers/Basic_Deployment_Data.hpp:
    * tools/Config_Handlers/Deployment.cpp:
    * tools/Config_Handlers/XMI.cpp:
    * tools/Config_Handlers/XMI.hpp:
    * tools/Config_Handlers/ccd.cpp:
    * tools/Config_Handlers/ccd.hpp:
    * tools/Config_Handlers/cdd.cpp:
    * tools/Config_Handlers/cdd.hpp:
    * tools/Config_Handlers/cdp.cpp:
    * tools/Config_Handlers/cdp.hpp:
    * tools/Config_Handlers/cid.cpp:
    * tools/Config_Handlers/cid.hpp:
    * tools/Config_Handlers/cpd.cpp:
    * tools/Config_Handlers/cpd.hpp:
    * tools/Config_Handlers/iad.cpp:
    * tools/Config_Handlers/iad.hpp:
    * tools/Config_Handlers/pcd.cpp:
    * tools/Config_Handlers/pcd.hpp:
    * tools/Config_Handlers/toplevel.cpp:
    * tools/Config_Handlers/toplevel.hpp: